### PR TITLE
build: remove .NET Core 3.0 support

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,8 +25,6 @@ jobs:
         include:
           - dotnet-version: 2.1
             dotnet-sdk-version: 2.1.804
-          - dotnet-version: 3.0
-            dotnet-sdk-version: 3.0.103
           - dotnet-version: 3.1
             dotnet-sdk-version: 3.1.102
           - os: ubuntu-latest
@@ -99,11 +97,9 @@ jobs:
         dotnet-version: [3.1]
         include:
           - dotnet-version: 2.1
-            dotnet-sdk-version: 2.1.803
-          - dotnet-version: 3.0
-            dotnet-sdk-version: 3.0.102
+            dotnet-sdk-version: 2.1.804
           - dotnet-version: 3.1
-            dotnet-sdk-version: 3.1.101
+            dotnet-sdk-version: 3.1.102
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -114,9 +110,9 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ${{ github.workspace }}/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ matrix.dotnet-version }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
           restore-keys: |
-            nuget-${{ runner.os }}-
+            ${{ runner.os }}-nuget-
       - name: Restore File from release job
         uses: actions/download-artifact@v1
         with:

--- a/Sample.Core/Sample.Core.csproj
+++ b/Sample.Core/Sample.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Sample.Core/packages.lock.json
+++ b/Sample.Core/packages.lock.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.0": {}
+    ".NETCoreApp,Version=v3.1": {}
   }
 }

--- a/Sample.Test/Sample.Test.csproj
+++ b/Sample.Test/Sample.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Sample.Test/packages.lock.json
+++ b/Sample.Test/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v3.0": {
+    ".NETCoreApp,Version=v3.1": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[1.2.0, )",


### PR DESCRIPTION
.NET Core 3.0 will reach end of life on March 3, 2020.
This PR is removed build & test job on .NET Core 3.0.
## Support
|Ver|Phase|eol|
|----|------|---|
|1.0|eol|2019-06-27|
|1.1|eol|2019-06-27|
|2.0|eol|2018-10-01|
|2.1|lts|2021-08-21|
|2.2|eol|2019-12-23|
|3.0|maintenance|2020-03-03|
|3.1|lts|2022-12-03|
## Ref
- https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/
- https://github.com/dotnet/core/blob/master/release-notes/releases-index.json