### PR TITLE
ci: bump .NET Core SDK version

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -19,7 +19,7 @@ env:
   DOTNET_NOLOGO: "true"
   NUGET_XMLDOC_MODE: skip
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-  STABLE_SDK_VERSION: 3.1.201
+  STABLE_SDK_VERSION: 3.1.202
 
 jobs:
   lint:
@@ -48,11 +48,11 @@ jobs:
             # { version: "1.0", sdk: 1.1.14 }, # EOL
             # { version: "1.1", sdk: 1.1.14 }, # EOL
             # { version: "2.0", sdk: 2.1.202 }, # EOL
-            # { version: "2.1", sdk: 2.1.805 }, # LTS
+            # { version: "2.1", sdk: 2.1.806 }, # LTS
             # { version: "2.2", sdk: 2.2.207 }, # EOL
             # { version: "3.0", sdk: 3.0.103 }, # EOL
-            { version: "3.1", sdk: 3.1.201 }, # LTS
-            # { version: "5.0", sdk: 5.0.100-preview.2.20176.6 }, # preview
+            { version: "3.1", sdk: 3.1.202 }, # LTS
+            # { version: "5.0", sdk: 5.0.100-preview.3.20216.6 }, # preview
           ]
     steps:
       - uses: actions/checkout@v2
@@ -116,11 +116,11 @@ jobs:
             # { version: "1.0", sdk: 1.1.14 }, # EOL
             # { version: "1.1", sdk: 1.1.14 }, # EOL
             # { version: "2.0", sdk: 2.1.202 }, # EOL
-            # { version: "2.1", sdk: 2.1.805 }, # LTS
+            # { version: "2.1", sdk: 2.1.806 }, # LTS
             # { version: "2.2", sdk: 2.2.207 }, # EOL
             # { version: "3.0", sdk: 3.0.103 }, # EOL
-            { version: "3.1", sdk: 3.1.201 }, # LTS
-            # { version: "5.0", sdk: 5.0.100-preview.2.20176.6 }, # preview
+            { version: "3.1", sdk: 3.1.202 }, # LTS
+            # { version: "5.0", sdk: 5.0.100-preview.3.20216.6 }, # preview
           ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## .NET Core May 2020 Updates
- .NET Core 2.1 (LTS)
  - `2.1.805` -> `2.1.806`
  - [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.18/2.1.18.md)
- .NET Core 3.1 (Current, LTS)
  - `3.1.201` -> `3.1.202`
  - [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.4/3.1.4.md)

see: https://devblogs.microsoft.com/dotnet/net-core-may-2020/

----

## .NET 5.0 Preview 3
- .NET 5.0 (Preview)
  - `5.0.100-preview.2.20176.6` -> `5.0.100-preview.3.20216.6`
  - [Release Notes](https://github.com/dotnet/core/blob/master/release-notes/5.0/preview/5.0.0-preview.3.md)

see: https://devblogs.microsoft.com/dotnet/announcing-net-5-0-preview-3/
