### PR TITLE
refactor(ci): optimize CI/CD runs

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -55,9 +55,7 @@ jobs:
       - name: Restore
         run: dotnet restore --force-evaluate
       - name: Run ECLint
-        run: |
-          npm install -g eclint
-          eclint fix "**/packages.lock.json"
+        run: npx eclint fix "**/packages.lock.json"
       - name: Diff
         id: diff
         continue-on-error: true
@@ -104,4 +102,5 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.0.0
         with:
-          flags: ${{ runner.os }}
+          flags: ${{ runner.os }},${{ matrix.framework }}
+          files: "*.opencover.xml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
   publish-nuget:
     name: Publish to NuGet
     needs: [build]
-    if: ${{ secrets.NUGET_API_KEY }}
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Setup .NET SDK # detected from global.json


### PR DESCRIPTION
- Disable "Publish to NuGet" workflow
- Use `npx` command
- Add `files` param to reduce upload size