### PR TITLE
ci(gh-actions): add Problem Matchers for `dotnet-format`

### DIFF
--- a/.github/dotnet-format.json
+++ b/.github/dotnet-format.json
@@ -1,0 +1,19 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "dotnet-format",
+      "pattern": [
+        {
+          "regexp": "^\\s*(.*)\\((\\d+),(\\d+)\\):\\s+(error|warning)\\s+(.+):\\s+(.*)\\s+\\[(.+)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "code": 5,
+          "message": 6,
+          "fromPath": 7
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET SDK # detected from global.json
         uses: actions/setup-dotnet@v4.2.0
       - name: Add Problem Matcher for dotnet-format
-        uses: xt0rted/dotnet-format-problem-matcher@v1.2.0
+        run: echo "::add-matcher::.github/dotnet-format.json"
       - name: Lint
         run: dotnet format --verify-no-changes --verbosity detailed
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.101",
+    "version": "9.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- [Reference](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md)

Log format is based on [here](https://github.com/dotnet/sdk/blob/6a9cf09b996f2c20664b6d307250942265ab3f3b/src/BuiltInTools/dotnet-format/Logging/MSBuildIssueFormatter.cs#L8)